### PR TITLE
Fix PWA reloading and GitHub Pages path issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Bíblia Sagrada</title>
 
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
+  <link rel="manifest" href="site.webmanifest">
 
   <!-- Bootstrap 5 -->
   <link href="css/bootstrap.min.css" rel="stylesheet" />

--- a/js/script.js
+++ b/js/script.js
@@ -501,7 +501,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
 if ('serviceWorker' in navigator) {
     // Timestamp impede que o navegador sirva um SW antigo do cache CDN
-    const swUrl = `/sw.js?v=${Date.now()}`;
+    const swUrl = 'sw.js';
     let isRefreshing = false; // Trava para evitar múltiplos reloads
 
     navigator.serviceWorker.register(swUrl, { updateViaCache: 'none' })
@@ -533,13 +533,4 @@ if ('serviceWorker' in navigator) {
         window.location.reload();
     });
 
-    // Escuta mensagens de atualização do SW
-    navigator.serviceWorker.addEventListener('message', event => {
-        if (event.data?.type === 'SW_UPDATED') {
-            if (isRefreshing) return;
-            isRefreshing = true;
-            console.log('[SW] Mensagem de atualização recebida. Recarregando...');
-            window.location.reload();
-        }
-    });
 }

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -2,17 +2,17 @@
     "name": "Bíblia Sagrada",
     "short_name": "Bíblia",
     "description": "Leia a Bíblia Sagrada em português",
-    "start_url": "/",
-    "scope": "/",
+    "start_url": "./",
+    "scope": "./",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png",
             "purpose": "any maskable"
         },
         {
-            "src": "/android-chrome-512x512.png",
+            "src": "android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png",
             "purpose": "any maskable"

--- a/sw.js
+++ b/sw.js
@@ -3,31 +3,31 @@
    v25 – FORCE UPDATE / GITHUB PAGES COMPATIBLE
    =========================================================== */
 
-const CACHE_VERSION = 'v26'; // ← INCREMENTE SEMPRE QUE FIZER DEPLOY
+const CACHE_VERSION = 'v27'; // ← INCREMENTE SEMPRE QUE FIZER DEPLOY
 const CACHE_NAME    = `bible-sagrada-${CACHE_VERSION}`;
 const PRECACHE_NAME = `${CACHE_NAME}-precache`;
 const RUNTIME_NAME  = `${CACHE_NAME}-runtime`;
 
 const PRECACHE_URLS = [
-  '/',
-  '/index.html',
-  '/offline.html',
-  '/site.webmanifest',
-  '/android-chrome-192x192.png',
-  '/android-chrome-512x512.png',
-  '/apple-touch-icon.png',
-  '/favicon-16x16.png',
-  '/favicon-32x32.png',
-  '/favicon.ico',
-  '/css/style.css',
-  '/css/bootstrap.min.css',
-  '/js/daily.js',
-  '/js/bible-data.js',
-  '/js/bootstrap.min.js',
-  '/js/script.js',
-  '/js/sidebar.js',
-  '/js/teens.js',
-  '/js/splash.js'
+  './',
+  'index.html',
+  'offline.html',
+  'site.webmanifest',
+  'android-chrome-192x192.png',
+  'android-chrome-512x512.png',
+  'apple-touch-icon.png',
+  'favicon-16x16.png',
+  'favicon-32x32.png',
+  'favicon.ico',
+  'css/style.css',
+  'css/bootstrap.min.css',
+  'js/daily.js',
+  'js/bible-data.js',
+  'js/bootstrap.min.js',
+  'js/script.js',
+  'js/sidebar.js',
+  'js/teens.js',
+  'js/splash.js'
 ];
 
 const DEBUG = true;
@@ -65,13 +65,6 @@ self.addEventListener('activate', event => {
         })
       ))
       .then(() => self.clients.claim())
-      .then(() => self.clients.matchAll({ type: 'window', includeUncontrolled: true }))
-      .then(clients => {
-        log(`Notifying ${clients.length} client(s) to reload`);
-        clients.forEach(client =>
-          client.postMessage({ type: 'SW_UPDATED', version: CACHE_VERSION })
-        );
-      })
   );
 });
 


### PR DESCRIPTION
I've fixed the infinite reloading loop and ensured the PWA works correctly on GitHub Pages by making all asset paths relative. I also cleaned up the Service Worker registration and activation logic to be more robust and standard-compliant.

---
*PR created automatically by Jules for task [10462008483251486558](https://jules.google.com/task/10462008483251486558) started by @eduardo2580*