### PR TITLE
Prioritize offline male Brazilian Portuguese TTS voice

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -485,9 +485,28 @@ function initTTS() {
 
     function pickVoice() {
         const voices = synth.getVoices();
-        return voices.find(v => v.lang === 'pt-BR')
-            || voices.find(v => v.lang.startsWith('pt'))
-            || null;
+        // Standardize lang tags to 'pt-BR'
+        const ptBR = voices.filter(v => v.lang.replace('_', '-') === 'pt-BR');
+
+        if (ptBR.length === 0) {
+            return voices.find(v => v.lang.startsWith('pt')) || null;
+        }
+
+        // Common male voice names/keywords in Brazilian Portuguese
+        const maleKeywords = ['daniel', 'antonio', 'ricardo', 'felipe', 'guilherme', 'thiago', 'male', 'masculino'];
+
+        const getScore = (v) => {
+            let score = 0;
+            const name = v.name.toLowerCase();
+            // Prioritize local (offline) voices
+            if (v.localService) score += 10;
+            // Prioritize masculine voices
+            if (maleKeywords.some(k => name.includes(k))) score += 5;
+            return score;
+        };
+
+        ptBR.sort((a, b) => getScore(b) - getScore(a));
+        return ptBR[0];
     }
 
     function speak() {


### PR DESCRIPTION
The Text-to-Speech (TTS) functionality has been improved to better align with the user's request for a natural male Brazilian Portuguese voice that works offline. 

Changes:
1. **Enhanced Voice Selection**: The `pickVoice` function in `js/script.js` now uses a scoring system to rank available voices.
2. **Offline Priority**: Voices with the `localService` property are prioritized (10 points) to ensure the PWA's offline goal is met.
3. **Gender Preference**: Voices with masculine names (e.g., 'Daniel', 'Antonio', 'Ricardo', 'Felipe', 'Guilherme', 'Thiago') or keywords like 'male'/'masculino' are given additional priority (5 points).
4. **Fallback Mechanism**: The logic gracefully falls back to any Brazilian Portuguese voice, and finally to any Portuguese voice, if the preferred options are not present on the user's system.
5. **Language Standardization**: The code now handles both 'pt-BR' and 'pt_BR' formats commonly returned by different browsers.

---
*PR created automatically by Jules for task [14080598080208413109](https://jules.google.com/task/14080598080208413109) started by @eduardo2580*